### PR TITLE
Add RootHash to L1BlockInfo

### DIFF
--- a/op-node/rollup/derive/l1_block_info.go
+++ b/op-node/rollup/derive/l1_block_info.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	L1InfoFuncSignature = "setL1BlockValues(uint64,uint64,uint256,bytes32,uint64,bytes32,uint256,uint256)"
-	L1InfoArguments     = 8
+	L1InfoArguments     = 9
 	L1InfoLen           = 4 + 32*L1InfoArguments
 )
 


### PR DESCRIPTION
- The change is necessary for IBC clients so they can verify consensus updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced block information tracking with the addition of a new RootHash field to improve data integrity and verification processes.

- **Improvements**
  - Updated data serialization and deserialization methods to accommodate the new RootHash field, ensuring seamless integration with existing systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->